### PR TITLE
Use X-Api-Key if provided.

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -61,6 +61,13 @@ func AirflowProvider() *schema.Provider {
 				Description: "Disable SSL verification",
 				Default:     false,
 			},
+			"x_api_key": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "The API key to use for header (X-Api-Key) authentication",
+				ConflictsWith: []string{"username", "oauth2_token"},
+				DefaultFunc:   schema.EnvDefaultFunc("AIRFLOW_X_API_KEY", nil),
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"airflow_connection": resourceConnection(),
@@ -134,6 +141,10 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 				Description: "Apache Airflow Stable API.",
 			},
 		},
+	}
+
+	if xApiKey, ok := d.GetOk("x_api_key"); ok {
+		clientConf.DefaultHeader["X-Api-Key"] = xApiKey.(string)
 	}
 
 	prov := ProviderConfig{


### PR DESCRIPTION
# Context

https://github.com/halter-corp/tls-sso-reverse-proxy/pull/2

halter-corp/airflow deployed behind tls-sso-reverse-proxy.

We will poke a hole in SSO to allow API access from Terraform, so that we can use the provider to provision Airflow Variables from inside halter-corp/airflow-dags.

This will enable DAG authors to inject references to resources into their DAG definitions. E.g. IAM Roles, compute, storage, etc.